### PR TITLE
Add compatibility with CentOS 7

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -6,5 +6,8 @@
 - name: Preflight - Fail if host is not suitable for this benchmark
   fail:
     msg: "This benchmark is not suitable for the destination operating system, ansible_distribution is - {{ ansible_distribution }}, ansible_distribution_version is - {{ ansible_distribution_version }}, ansible_distribution_version is {{ ansible_distribution_version }}, cis_target_os_versions is {{ cis_target_os_versions }}, cis_target_os_distribution is {{ cis_target_os_distribution }}"
-  when: (ansible_distribution is not defined) or (ansible_distribution_version is not defined) or (ansible_distribution_version not in cis_target_os_versions) or (ansible_distribution not in cis_target_os_distribution)
+  when: (ansible_distribution is not defined) or
+        (ansible_distribution_version is not defined) or
+        (ansible_distribution_major_version+"."+ansible_distribution_version.split('.')[1]|default('0') not in cis_target_os_versions) or
+        (ansible_distribution not in cis_target_os_distribution)
   tags: always

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,6 +5,7 @@
 # cis_target_os_distribution: "Amazon"
 cis_target_os_distribution:
   - "RedHat"
+  - "CentOS"
 cis_target_os_versions:
   - "7.0"
   - "7.1"


### PR DESCRIPTION
I forked this earlier today to make it work on CentOS 7. Would you be interested in merging?


---
On CentOS 7 latest, variables are like:
- `ansible_distribution`: CentOS
- `ansible_distribution_version`: 7.4.1708