### PR TITLE
Update 2.2.1.2 to be analog to 2.2.1.3

### DIFF
--- a/tasks/level-1/2.2.1.2.yml
+++ b/tasks/level-1/2.2.1.2.yml
@@ -12,6 +12,7 @@
     group: root
     backup: true
   notify: Restart ntpd
+  when: cis_enable_ntp and not cis_enable_chrony
   tags:
     - level-1
     - section-4


### PR DESCRIPTION
Added the conditional check to ensure configuration is only done when chrony is disabled and ntp enabled. Compare 2.2.1.3. for reference.