### PR TITLE
Remove double underscore

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -222,7 +222,7 @@ cis_v_3_2_5_ipv4_icmp_echo_ignore_broadcasts: { proc_src: '/proc/sys/net/ipv4/ic
 cis_v_3_2_5_ipv4_route_flush: { proc_src: '/proc/sys/net/ipv4/route/flush', kernel_param: 'flush', value: 1 }
 
 # 3.2.6
-cis_v_3_2_6_ipv4_icmp_echo_ignore_bogus_error_responses: { proc_src: '/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses', kernel_param: 'net.ipv4.icmp__ignore_bogus_error_responses', value: 1 }
+cis_v_3_2_6_ipv4_icmp_echo_ignore_bogus_error_responses: { proc_src: '/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses', kernel_param: 'net.ipv4.icmp_ignore_bogus_error_responses', value: 1 }
 cis_v_3_2_6_ipv4_route_flush: { proc_src: '/proc/sys/net/ipv4/route/flush', kernel_param: 'flush', value: 1 }
 
 # 3.2.7


### PR DESCRIPTION
This was causing an error when we tried to restart the sysctl service. Pretty sure this is a typo.