### PR TITLE
Add CentOS 7.7 support. Fix issue with reloading auditd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,4 +33,4 @@
   service:
     name: auditd
     state: reloaded
-    use: service
+    use: sysvinit

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,6 +14,7 @@ cis_target_os_versions:
   - "7.4"
   - "7.5"
   - "7.6"
+  - "7.7"
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"
 # cis_grub_bootloader_filename: "/boot/grub/menu.lst"


### PR DESCRIPTION
Tested on CentOS 7.6 and 7.7.

`use: sysvinit` fix comes from https://github.com/ansible/ansible/issues/37590#issuecomment-408087774

Using `service` causes Ansible to auto-detect the system type as systemd, so you get the following error (from `systemctl`):

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to reload auditd.service: Job type reload is not applicable for unit auditd.service.\nSee system logs and 'systemctl status auditd.service' for details.\n"}
```