### PR TITLE
Reload auditd using legacy init script

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -30,7 +30,4 @@
     state: restarted
 
 - name: Restart auditd
-  service:
-    name: auditd
-    state: reloaded
-    use: service
+  command: "/usr/sbin/service auditd reload"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -31,3 +31,4 @@
 
 - name: Restart auditd
   command: "/usr/sbin/service auditd reload"
+  warn: false


### PR DESCRIPTION
According to [this comment](https://github.com/linux-audit/audit-userspace/commit/85f9628c71865f966daef75c89ea86953d72931e#diff-921842c9247ba2c61016aa328e9a45df), auditd still uses legacy SysV init scripts to start/stop/reload.
CentOS 7.6 reports this error when try to reload auditd usings `systemctl`:

```
Failed to reload auditd.service: Job type reload is not applicable for unit auditd.service.
See system logs and 'systemctl status auditd.service' for details.
```