### PR TITLE
Update to allow RHEL 7.7

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,6 +14,7 @@ cis_target_os_versions:
   - "7.4"
   - "7.5"
   - "7.6"
+  - "7.7"
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_aide_database_filename: "/var/lib/aide/aide.db.gz"
 # cis_grub_bootloader_filename: "/boot/grub/menu.lst"


### PR DESCRIPTION
Updated the vars file to allow CIS benchmarks to run against RHEL/CentOS version 7.7